### PR TITLE
Debug white screen error

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,20 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@theme {
+  --color-gray-50: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-800: #1f2937;
+  --color-gray-900: #111827;
+  --color-gray-950: #030712;
+}
 
 @layer base {
   :root {
@@ -99,7 +111,7 @@
   button,
   textarea,
   select {
-    @apply font-inherit;
+    font-family: inherit;
   }
 
   /* Text wrapping */


### PR DESCRIPTION
Update Tailwind CSS v4 configuration to resolve white screen and build errors.

The white screen was caused by an incompatibility with Tailwind CSS v4. The previous configuration used v3 syntax, leading to build errors such as "Cannot apply unknown utility class `bg-gray-900`" and issues with `@apply font-inherit`. This PR updates the CSS imports to the correct v4 `@import "tailwindcss"` and adds the necessary `@theme` directive with gray color definitions, along with converting `font-inherit` to standard CSS.

---

[Open in Web](https://www.cursor.com/agents?id=bc-4fba089d-43f1-4018-be06-a12cb59dd6a7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4fba089d-43f1-4018-be06-a12cb59dd6a7)